### PR TITLE
Add support for *.tar.zst format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ installed:
   - *.tar.gz*, *.tgz* require `tar` (optionally `pigz`).
   - *.tar.bz2*, *.tbz* require `tar` (optionally `pbzip2`).
   - *.tar.xz*, *.txz* require `tar` with *xz* support.
+  - *.tar.zst* requires `tar` with *zstd* support.
   - *.tar.lzma*, *.tlz* require `tar` with *lzma* support.
   - *.tar* requires `tar`.
   - *.gz* requires `gunzip`.

--- a/_lsarchive
+++ b/_lsarchive
@@ -9,4 +9,4 @@
 
 '_arguments'                    \
   '-v[verbose archive listing]' \
-  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|lzma|zip|jar|rar|7z)(-.)'"
+  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|zst|lzma|zip|jar|rar|7z)(-.)'"

--- a/_unarchive
+++ b/_unarchive
@@ -9,4 +9,4 @@
 
 '_arguments'              \
   '-r[remove archive(s)]' \
-  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|lzma|Z|zip|jar|rar|7z|deb)(-.)'"
+  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|zst|lzma|Z|zip|jar|rar|7z|deb)(-.)'"

--- a/archive
+++ b/archive
@@ -40,6 +40,7 @@ case $archive in
   *.tar.gz|*.tgz)         tar -cvf $archive --use-compress-program=$gzip  "$@";;
   *.tar.bz2|*.tbz|*.tbz2) tar -cvf $archive --use-compress-program=$bzip2 "$@";;
   *.tar.xz|*.txz)         tar -cvf $archive --use-compress-program=$xz    "$@";;
+  *.tar.zst)              tar -cvf $archive --use-compress-program=zstd   "$@";;
   *.tar.lzma|*.tlz)       tar -cvf $archive --lzma                        "$@";;
   *.tar)                  tar -cvf $archive                               "$@";;
   *.zip|*.jar)            zip -r   $archive                               "$@";;

--- a/lsarchive
+++ b/lsarchive
@@ -34,6 +34,8 @@ for archive in "${@:$OPTIND}"; do
       tar tjf$v $archive;;
     *.tar.xz|*.txz)
       tar --xz --help &>/dev/null && tar --xz -tf$v $archive || xzcat $archive | tar tf$v -;;
+    *.tar.zst)
+      tar --zstd --help &>/dev/null && tar --zstd -tf$v $archive || zstdcat $archive | tar tf$v -;;
     *.tar.lzma|*.tlz)
       tar --lzma --help &> /dev/null && tar --lzma -tf$v $archive || lzcat $archive | tar xf$v -;;
     *.tar)

--- a/unarchive
+++ b/unarchive
@@ -38,6 +38,8 @@ for archive in "${@:$OPTIND}"; do
       tar -xvf $archive --use-compress-program=$bzip2;;
     *.tar.xz|*.txz)
       tar -xvf $archive --use-compress-program=$xz;;
+    *.tar.zst)
+      tar -xvf $archive --use-compress-program=zstd;;
     *.tar.lzma|*.tlz)
       tar --lzma --help &>/dev/null && tar --lzma -xvf $archive || lzcat $archive | tar -xvf -;;
     *.tar)


### PR DESCRIPTION
Apart from [a proposal](https://github.com/facebook/zstd/issues/767#issuecomment-395640696), I haven't found any mention for an established short extension for `.tar.zst` (like `.tzs`) nor have I seen any used in real life, so I didn't add it.